### PR TITLE
Delegation app fix

### DIFF
--- a/encoins-relay-apps/encoins-relay-apps.cabal
+++ b/encoins-relay-apps/encoins-relay-apps.cabal
@@ -62,6 +62,7 @@ library
       plutus-ledger                          -any,
       plutus-ledger-api                      -any,
       plutus-tx                              -any,
+      terminal-progress-bar                  -any,
       text                                   -any,
       time                                   -any,
       transformers                           -any,

--- a/encoins-relay-apps/encoins-relay-apps.cabal
+++ b/encoins-relay-apps/encoins-relay-apps.cabal
@@ -20,13 +20,13 @@ common lang
       -Wredundant-constraints
       -Wno-unused-do-bind
       -Wall
-      
+
       -- See Plutus Tx readme
       -fno-ignore-interface-pragmas
       -fno-omit-interface-pragmas
       -fno-specialise
       -fno-strictness
-      -fobject-code       
+      -fobject-code
       -fplugin-opt PlutusTx.Plugin:defer-errors
 
 library
@@ -40,6 +40,7 @@ library
     build-depends:
       base                          >= 4.9 && < 5,
       aeson                                  -any,
+      async                                  -any,
       bytestring                             -any,
       cardano-api                            -any,
       cardano-ledger-babbage                 -any,
@@ -70,7 +71,7 @@ executable encoins-relay-poll
   default-language: Haskell2010
   hs-source-dirs: app_poll
   main-is: Main.hs
-  build-depends: 
+  build-depends:
     base                          >= 4.9 && < 5,
     encoins-relay-apps                         ,
 
@@ -79,6 +80,6 @@ executable encoins-relay-delegation
   default-language: Haskell2010
   hs-source-dirs: app_deleg
   main-is: Main.hs
-  build-depends: 
+  build-depends:
     base                          >= 4.9 && < 5,
     encoins-relay-apps                     -any,

--- a/encoins-relay-apps/src/Encoins/Relay/Apps/Delegation/Main.hs
+++ b/encoins-relay-apps/src/Encoins/Relay/Apps/Delegation/Main.hs
@@ -110,7 +110,10 @@ findDelegators delegationFolder DelegationHandle{..} slotFrom = do
                          . sortBy (compare `on` delegStakeKey)
 
 isValidIp :: Text -> Bool
-isValidIp txt = or $ [isURI, isIPv4address] <&> ($ T.unpack txt)
+isValidIp txt = or $ [isSimpleURI, isURI, isIPv4address] <&> ($ T.unpack txt)
+    where
+        isSimpleURI "" = False
+        isSimpleURI _  = case T.splitOn "." txt of [_, _] -> True; _ -> False
 
 data DelegationHandle m = DelegationHandle
     { dhGetResponses     :: Maybe Slot -> Maybe Slot -> m [KupoResponse]

--- a/encoins-relay-apps/src/Encoins/Relay/Apps/Delegation/Main.hs
+++ b/encoins-relay-apps/src/Encoins/Relay/Apps/Delegation/Main.hs
@@ -83,9 +83,10 @@ findDelegators delegationFolder DelegationHandle{..} slotFrom = do
         !responses <- dhGetResponses (Just slotFrom) Nothing
         pb <- dhNewProgressBar "Getting delegated txs" $ length responses
         fmap (removeDuplicates . catMaybes) $ forM responses $ \KupoResponse{..} -> runMaybeT $ do
-            lift $ dhIncProgress pb 1
-            dhWithResultSaving (mconcat [delegationFolder, "/deleg_", show krTxId, "@", show krOutputIndex, ".json"]) $
+            d <- dhWithResultSaving (mconcat [delegationFolder, "/deleg_", show krTxId, "@", show krOutputIndex, ".json"]) $
                 getDelegationFromResponse KupoResponse{..}
+            lift $ dhIncProgress pb 1
+            pure d
     where
         -- Token balance validation occurs at rewards distribution
         getDelegationFromResponse :: KupoResponse -> MaybeT m Delegation

--- a/encoins-relay-apps/src/Encoins/Relay/Apps/Delegation/Main.hs
+++ b/encoins-relay-apps/src/Encoins/Relay/Apps/Delegation/Main.hs
@@ -58,7 +58,7 @@ main configFp = do
         let handle = mkDelegationHandle config slotConfig
         createDirectoryIfMissing True $ cDelegationFolder relayConfig
         forever $ do
-            ct                         <- Time.getCurrentTime
+            ct                         <- Time.addUTCTime (- 1800) <$> Time.getCurrentTime
             delay                      <- async $ waitTime 300
             (mbPastDelegators, mbTime) <- getPastDelegators $ cDelegationFolder relayConfig
             let start = maybe (cDelegationStart relayConfig) (utcToSlot slotConfig) mbTime


### PR DESCRIPTION
- [x] Change datum format to ```["ENCOINS", "Delegate", <stake key hash>, <url>]```
- [x] Get the required stake key from the datum, not from the response
- [x] Add a delay between iterations of searching for delegators to prevent spam when delegation app is synchronized
- [x] FIx terminal spam with progress messages logs. Use one-line progress bar instead
- [x] Fix searching for files with previous delegations
- [x] Fix valid delegation-ip criteria